### PR TITLE
Add group policy to disable webtorrent

### DIFF
--- a/browser/policy/brave_simple_policy_map.h
+++ b/browser/policy/brave_simple_policy_map.h
@@ -46,6 +46,8 @@ inline constexpr PolicyToPreferenceMapEntry kBraveSimplePolicyMap[] = {
      kManagedBraveShieldsEnabledForUrls, base::Value::Type::LIST},
     {policy::key::kBraveSyncUrl, brave_sync::kCustomSyncServiceUrl,
      base::Value::Type::STRING},
+    {policy::key::kWebTorrentDisabled,
+     webtorrent::prefs::kWebTorrentDisabledByPolicy, base::Value::Type::BOOLEAN},
 #endif
 
 #if BUILDFLAG(ENABLE_TOR)

--- a/components/brave_webtorrent/browser/webtorrent_util.cc
+++ b/components/brave_webtorrent/browser/webtorrent_util.cc
@@ -16,6 +16,8 @@
 #include "extensions/common/constants.h"
 #include "net/http/http_content_disposition.h"
 #include "net/http/http_response_headers.h"
+#include "brave/components/webtorrent/common/pref_names.h"
+#include "components/prefs/pref_service.h"
 
 namespace webtorrent {
 

--- a/components/brave_webtorrent/browser/webtorrent_util.cc
+++ b/components/brave_webtorrent/browser/webtorrent_util.cc
@@ -47,6 +47,12 @@ bool IsWebtorrentEnabled(content::BrowserContext* browser_context) {
   if (!registry) {
     return false;
   }
+
+  PrefService* prefs = Profile::FromBrowserContext(browser_context)->GetPrefs();
+  if (prefs && prefs->GetBoolean(webtorrent::prefs::kWebTorrentDisabledByPolicy)) {
+      return false;
+  }
+
   return registry->enabled_extensions().Contains(brave_webtorrent_extension_id);
 }
 

--- a/components/brave_webtorrent/common/pref_names.h
+++ b/components/brave_webtorrent/common/pref_names.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_WEBTORRENT_COMMON_PREF_NAMES_H_
+#define BRAVE_COMPONENTS_WEBTORRENT_COMMON_PREF_NAMES_H_
+
+namespace webtorrent {
+namespace prefs {
+
+inline constexpr char kWebTorrentDisabledByPolicy[] =
+    "webtorrent.disabled_by_policy";
+
+}  // namespace prefs
+}  // namespace webtorrent
+
+#endif  // BRAVE_COMPONENTS_WEBTORRENT_COMMON_PREF_NAMES_H_

--- a/components/policy/resources/templates/policy_definitions/BraveSoftware/BraveWebtorrentDisabled.yaml
+++ b/components/policy/resources/templates/policy_definitions/BraveSoftware/BraveWebtorrentDisabled.yaml
@@ -1,0 +1,37 @@
+caption: Disable WebTorrent
+default: null
+desc: |-
+  Disable WebTorrent in Brave.
+
+  WebTorrent is a feature that allows users to stream and download torrents directly in Brave.
+
+            If this policy is set to true, WebTorrent will always be disabled.
+
+            If this policy is set to false, WebTorrent will always be enabled.
+
+            If you set this policy, users cannot change or override it.
+
+            If this policy is left unset, WebTorrent will be enabled by default.
+example_value: true
+features:
+  can_be_mandatory: true
+  can_be_recommended: false
+  dynamic_refresh: false
+  per_profile: true
+items:
+- caption: Enable WebTorrent
+  value: false
+- caption: Disable WebTorrent
+  value: true
+- caption: Allow the user to decide
+  value: null
+owners:
+- bbondy@brave.com
+- peter@brave.com
+- clifton@brave.com
+schema:
+  type: boolean
+supported_on:
+  - chrome.*:105-
+tags: []
+type: main


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

